### PR TITLE
feat: Support registering handlers that load an external inventory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ include = [
 python = "^3.6"
 Markdown = "^3.3"
 mkdocs = "^1.1"
+importlib_metadata = {version = "^4.0", python = "<3.8"}
 
 [tool.poetry.dev-dependencies]
 autoflake = "^1.4"


### PR DESCRIPTION
### refactor: Move the code relativizing a URL, so absolute URLs can bypass it

### feat: Support registering handlers that load an external inventory

These identifiers are then possible to refer to, they're checked against and substituted (as absolute URLs) in case there's no such identifier on the current site.

Example of how an external handler can be registered:

* https://github.com/mkdocstrings/crystal/compare/inv#commit_comments_bucket

* ```yaml
  plugins:
    - autorefs:
        import:
          crystal:
            - https://crystal-lang.org/api/latest/index.json
  ```