### PR TITLE
feat: Allow registering absolute URLs for autorefs

### DIFF
--- a/src/mkdocs_autorefs/references.py
+++ b/src/mkdocs_autorefs/references.py
@@ -125,7 +125,7 @@ def relative_url(url_a: str, url_b: str) -> str:
     return f"{relative}#{anchor}"
 
 
-def fix_ref(url_mapper: Callable[[str], str], from_url: str, unmapped: List[str]) -> Callable:
+def fix_ref(url_mapper: Callable[[str], str], unmapped: List[str]) -> Callable:
     """Return a `repl` function for [`re.sub`](https://docs.python.org/3/library/re.html#re.sub).
 
     In our context, we match Markdown references and replace them with HTML links.
@@ -137,7 +137,6 @@ def fix_ref(url_mapper: Callable[[str], str], from_url: str, unmapped: List[str]
     Arguments:
         url_mapper: A callable that gets an object's site URL by its identifier,
             such as [mkdocs_autorefs.plugin.AutorefsPlugin.get_item_url][].
-        from_url: The URL of the base page, from which we link towards the targeted pages.
         unmapped: A list to store unmapped identifiers.
 
     Returns:
@@ -150,7 +149,7 @@ def fix_ref(url_mapper: Callable[[str], str], from_url: str, unmapped: List[str]
         title = match["title"]
 
         try:
-            url = relative_url(from_url, url_mapper(unescape(identifier)))
+            url = url_mapper(unescape(identifier))
         except KeyError:
             unmapped.append(identifier)
             if title == identifier:
@@ -162,16 +161,11 @@ def fix_ref(url_mapper: Callable[[str], str], from_url: str, unmapped: List[str]
     return inner
 
 
-def fix_refs(
-    html: str,
-    from_url: str,
-    url_mapper: Callable[[str], str],
-) -> Tuple[str, List[str]]:
+def fix_refs(html: str, url_mapper: Callable[[str], str]) -> Tuple[str, List[str]]:
     """Fix all references in the given HTML text.
 
     Arguments:
         html: The text to fix.
-        from_url: The URL at which this HTML is served.
         url_mapper: A callable that gets an object's site URL by its identifier,
             such as [mkdocs_autorefs.plugin.AutorefsPlugin.get_item_url][].
 
@@ -179,7 +173,7 @@ def fix_refs(
         The fixed HTML.
     """
     unmapped = []  # type: ignore
-    html = AUTO_REF_RE.sub(fix_ref(url_mapper, from_url, unmapped), html)
+    html = AUTO_REF_RE.sub(fix_ref(url_mapper, unmapped), html)
     return html, unmapped
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,42 @@
+"""Tests for the plugin module."""
+import pytest
+
+from mkdocs_autorefs.plugin import AutorefsPlugin
+
+
+def test_url_registration():
+    """Check that URLs can be registered, then obtained."""
+    plugin = AutorefsPlugin()
+    plugin.register_anchor(identifier="foo", page="foo1.html")
+    plugin.register_url(identifier="bar", url="https://example.org/bar.html")
+
+    assert plugin.get_item_url("foo") == "foo1.html#foo"
+    assert plugin.get_item_url("bar") == "https://example.org/bar.html"
+    with pytest.raises(KeyError):
+        plugin.get_item_url("baz")
+
+
+def test_url_registration_with_from_url():
+    """Check that URLs can be registered, then obtained, relative to a page."""
+    plugin = AutorefsPlugin()
+    plugin.register_anchor(identifier="foo", page="foo1.html")
+    plugin.register_url(identifier="bar", url="https://example.org/bar.html")
+
+    assert plugin.get_item_url("foo", from_url="a/b.html") == "../foo1.html#foo"
+    assert plugin.get_item_url("bar", from_url="a/b.html") == "https://example.org/bar.html"
+    with pytest.raises(KeyError):
+        plugin.get_item_url("baz", from_url="a/b.html")
+
+
+def test_url_registration_with_fallback():
+    """Check that URLs can be registered, then obtained through a fallback."""
+    plugin = AutorefsPlugin()
+    plugin.register_anchor(identifier="foo", page="foo1.html")
+    plugin.register_url(identifier="bar", url="https://example.org/bar.html")
+
+    assert plugin.get_item_url("baz", fallback=lambda s: "foo") == "foo1.html#foo"
+    assert plugin.get_item_url("baz", fallback=lambda s: "bar") == "https://example.org/bar.html"
+    with pytest.raises(KeyError):
+        plugin.get_item_url("baz", fallback=lambda s: "baaaa")
+    with pytest.raises(KeyError):
+        plugin.get_item_url("baz", fallback=lambda s: None)

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -48,7 +48,10 @@ def run_references_test(url_map, source, output, unmapped=None, from_url="page.h
     md = markdown.Markdown(extensions=[AutorefsExtension()])
     content = md.convert(source)
 
-    actual_output, actual_unmapped = fix_refs(content, from_url, url_map.__getitem__)
+    def url_mapper(identifier):
+        return relative_url(from_url, url_map[identifier])
+
+    actual_output, actual_unmapped = fix_refs(content, url_mapper)
     assert actual_output == output
     assert actual_unmapped == (unmapped or [])
 
@@ -86,6 +89,16 @@ def test_reference_with_punctuation():
         url_map={'Foo&"bar': 'foo.html#Foo&"bar'},
         source='This [Foo&"bar][].',
         output='<p>This <a href="foo.html#Foo&amp;&quot;bar">Foo&amp;"bar</a>.</p>',
+    )
+
+
+def test_reference_to_relative_path():
+    """Check references from a page at a nested path."""
+    run_references_test(
+        from_url="sub/sub/page.html",
+        url_map={"zz": "foo.html#zz"},
+        source="This [zz][].",
+        output='<p>This <a href="../../foo.html#zz">zz</a>.</p>',
     )
 
 


### PR DESCRIPTION
For now this is not used for anything, but the refactor is good for whatever plan we decide to go through regarding inventories.