### PR TITLE
fix: Prevent error during parallel installations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,6 @@ repository = "https://github.com/mkdocstrings/autorefs"
 homepage = "https://github.com/mkdocstrings/autorefs"
 keywords = ["mkdocs", "mkdocs-plugin", "docstrings", "autodoc"]
 packages = [ { include = "mkdocs_autorefs", from = "src" } ]
-include = [
-    "README.md",
-    "pyproject.toml"
-]
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
Poetry and PDM install packages in parallel.
By including README.md and pyproject.toml
in the project's metadata, they are included
in the final wheel, above the actual source files.
Upon installation, these two files are written
directly in site-packages.

If one or more other packages do the same thing,
it sometimes results in OS errors due to parallel
accesses to the same files.