### PR TITLE
Add hover text

### DIFF
--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -185,3 +185,12 @@ def test_custom_optional_reference():
     output, unmapped = fix_refs(source, url_map.__getitem__)
     assert output == 'foo <a href="ok.html#ok">ok</a>'
     assert unmapped == []
+
+
+def test_custom_optional_hover_reference():
+    """Check that optional-hover HTML-based references are expanded and never reported missing."""
+    url_map = {"ok": "ok.html#ok"}
+    source = '<span data-autorefs-optional-hover="bar">foo</span> <span data-autorefs-optional-hover=ok>ok</span>'
+    output, unmapped = fix_refs(source, url_map.__getitem__)
+    assert output == '<span title="bar">foo</span> <a title="ok" href="ok.html#ok">ok</a>'
+    assert unmapped == []


### PR DESCRIPTION
If the link text is not literally the full identifier, show the full identifier on hover.

This will be handy for the way I intend to handle https://github.com/mkdocstrings/mkdocstrings/issues/269