### PR TITLE
fix: Fix packaging (missing `__init__` module)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         key: tests-cache-${{ runner.os }}-${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: pdm install -G duty -G tests
+      run: pdm install --no-editable -G duty -G tests
 
     - name: Run the test suite
       run: pdm run duty test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ autorefs = "mkdocs_autorefs.plugin:AutorefsPlugin"
 [tool.pdm]
 version = {use_scm = true}
 package-dir = "src"
+editable-backend = "editables"
 
 [tool.pdm.dev-dependencies]
 duty = ["duty>=0.7"]

--- a/src/mkdocs_autorefs/__init__.py
+++ b/src/mkdocs_autorefs/__init__.py
@@ -1,0 +1,4 @@
+"""mkdocs-autorefs package.
+
+Automatically link across pages in MkDocs.
+"""


### PR DESCRIPTION
Turns out there never was an `__init__.py` module in the package, and Poetry was fine with it, while PDM is a bit more strict about how it finds namespace packages. Also, the local configuration prevented earlier detection of this packaging issue. This is fixed by using the `editables` editable-backend which does not add `src` to PYTHONPATH when testing. Detection would be improved if PDM failed instead of falling back to the `path` backend, see https://github.com/pdm-project/pdm/issues/958.
To further improve our practices, `--no-editable` is now used in CI.

Fixes issue #17 and mkdocstrings/mkdocstrings#398
