### PR TITLE
feat: Add option to scan and register HTML anchors

### DIFF
--- a/src/mkdocs_autorefs/plugin.py
+++ b/src/mkdocs_autorefs/plugin.py
@@ -50,8 +50,11 @@ class AutorefsPlugin(BasePlugin):
     for more information about its plugin system.
     """
 
+    config = (
+        ("scan_html_tags", mkdocs.config.config_options.Type(bool, default=False))
+    )
+
     scan_toc: bool = True
-    scan_html_tags: bool = True
     current_page: Optional[str] = None
 
     def __init__(self) -> None:
@@ -173,7 +176,7 @@ class AutorefsPlugin(BasePlugin):
             for item in page.toc.items:
                 self.map_urls(page.url, item)
 
-        if self.scan_html_tags:
+        if self.config["scan_html_tags"]:
             # Matches any html tag with the id property
             for match in re.findall(r"""<\w+? .*?id=["']([_\w-]*)["'].*?>""", html):
                 self.register_anchor(page.url, match)

--- a/src/mkdocs_autorefs/plugin.py
+++ b/src/mkdocs_autorefs/plugin.py
@@ -179,8 +179,8 @@ class AutorefsPlugin(BasePlugin):
                 self.map_urls(page.url, item)
 
         if self.config["scan_html_tags"]:
-            # Matches any html tag with the id property
-            for match in re.findall(r"""<\w+? .*?id=["']([_\w-]*)["'].*?>""", html):
+            # Matches any html anchor with the id property (<a id="xx">)
+            for match in re.findall(r"""<a .*?id=["']([_\w-]*)["'].*?>""", html):
                 self.register_anchor(page.url, match)
 
         return html

--- a/src/mkdocs_autorefs/plugin.py
+++ b/src/mkdocs_autorefs/plugin.py
@@ -179,8 +179,8 @@ class AutorefsPlugin(BasePlugin):
                 self.map_urls(page.url, item)
 
         if self.config["scan_html_tags"]:
-            # Matches any html anchor with the id property (<a id="xx">)
-            for match in re.findall(r"""<a .*?id=["']([_\w-]*)["'].*?>""", html):
+            # Matches any html anchors with the id property (e.g. <a id="xx">)
+            for match in re.findall(r"""<.*?id=["']([_\w-]*)["'].*?>""", html):
                 self.register_anchor(page.url, match)
 
         return html

--- a/src/mkdocs_autorefs/plugin.py
+++ b/src/mkdocs_autorefs/plugin.py
@@ -15,7 +15,8 @@ from __future__ import annotations
 import contextlib
 import functools
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Sequence
+import re
+from typing import Callable, Dict, Optional, Sequence
 from urllib.parse import urlsplit
 
 from mkdocs.plugins import BasePlugin
@@ -50,7 +51,8 @@ class AutorefsPlugin(BasePlugin):
     """
 
     scan_toc: bool = True
-    current_page: str | None = None
+    scan_html_tags: bool = True
+    current_page: Optional[str] = None
 
     def __init__(self) -> None:
         """Initialize the object."""
@@ -170,6 +172,12 @@ class AutorefsPlugin(BasePlugin):
             log.debug(f"Mapping identifiers to URLs for page {page.file.src_path}")
             for item in page.toc.items:
                 self.map_urls(page.url, item)
+
+        if self.scan_html_tags:
+            # Matches any html tag with the name property
+            for match in re.findall(r"""<(\w+?) .*?name=["']([\w-]*)["'].*?>.*?</\1>""", html):
+                self.register_anchor(page.url, match[1])
+
         return html
 
     def map_urls(self, base_url: str, anchor: AnchorLink) -> None:

--- a/src/mkdocs_autorefs/plugin.py
+++ b/src/mkdocs_autorefs/plugin.py
@@ -19,6 +19,8 @@ import re
 from typing import Callable, Dict, Optional, Sequence
 from urllib.parse import urlsplit
 
+from mkdocs.config import Config
+from mkdocs.config.config_options import Type
 from mkdocs.plugins import BasePlugin
 
 from mkdocs_autorefs.references import AutorefsExtension, fix_refs, relative_url
@@ -51,7 +53,7 @@ class AutorefsPlugin(BasePlugin):
     """
 
     config = (
-        ("scan_html_tags", mkdocs.config.config_options.Type(bool, default=False))
+        ("scan_html_tags", Type(bool, default=False))
     )
 
     scan_toc: bool = True

--- a/src/mkdocs_autorefs/plugin.py
+++ b/src/mkdocs_autorefs/plugin.py
@@ -174,9 +174,9 @@ class AutorefsPlugin(BasePlugin):
                 self.map_urls(page.url, item)
 
         if self.scan_html_tags:
-            # Matches any html tag with the name property
-            for match in re.findall(r"""<(\w+?) .*?id=["']([\w-]*)["'].*?>.*?</\1>""", html):
-                self.register_anchor(page.url, match[1])
+            # Matches any html tag with the id property
+            for match in re.findall(r"""<\w+? .*?id=["']([_\w-]*)["'].*?>""", html):
+                self.register_anchor(page.url, match)
 
         return html
 

--- a/src/mkdocs_autorefs/plugin.py
+++ b/src/mkdocs_autorefs/plugin.py
@@ -180,7 +180,7 @@ class AutorefsPlugin(BasePlugin):
 
         if self.config["scan_html_tags"]:
             # Matches any html anchors with the id property (e.g. <a id="xx">)
-            for match in re.findall(r"""<.*?id=["']([_\w-]*)["'].*?>""", html):
+            for match in re.findall(r"""<a .*?id=["']([_\w-]*)["'].*?>""", html):
                 self.register_anchor(page.url, match)
 
         return html

--- a/src/mkdocs_autorefs/plugin.py
+++ b/src/mkdocs_autorefs/plugin.py
@@ -175,7 +175,7 @@ class AutorefsPlugin(BasePlugin):
 
         if self.scan_html_tags:
             # Matches any html tag with the name property
-            for match in re.findall(r"""<(\w+?) .*?name=["']([\w-]*)["'].*?>.*?</\1>""", html):
+            for match in re.findall(r"""<(\w+?) .*?id=["']([\w-]*)["'].*?>.*?</\1>""", html):
                 self.register_anchor(page.url, match[1])
 
         return html


### PR DESCRIPTION
I noticed `autorefs` only scans the toc for anchors. This PR enhances the library by also searching for all html tags with the `id` attribute. The user might want to use `autorefs` to link to any arbitrary html tag that is not part of the toc. 

Use case: When documenting a Python class, every method can be preceded by a tag `<a id="method_name"></a>` to refer to it. Using markdown headers is not desired in this case because you don't want all the methods listed in the toc.