### PR TITLE
Add priority option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ plugins:
   - autorefs
 ```
 
+If a heading title that appears several times throughout the site, set the priority parameter to decide which page will be linked. The priority list follows the gitignore syntax and is tested in reverse: each anchor will be assigned the lowest priority amongst all of its matches.
+
+```yaml
+# mkdocs.yml
+plugins:
+  - search
+  - autorefs:
+    priority:
+      - '*' # priority to all files
+      - reference # except reference/... files 
+```
+
 In one of your Markdown files (e.g. `doc1.md`) create some headings:
 
 ```markdown
@@ -47,8 +59,6 @@ This works the same as [a normal link to that heading](../doc1.md#hello-world).
 ```
 
 Linking to a heading without needing to know the destination page can be useful if specifying that path is cumbersome, e.g. when the pages have deeply nested paths, are far apart, or are moved around frequently. And the issue is somewhat exacerbated by the fact that [MkDocs supports only *relative* links between pages](https://github.com/mkdocs/mkdocs/issues/1592).
-
-Note that this plugin's behavior is undefined when trying to link to a heading title that appears several times throughout the site. Currently it arbitrarily chooses one of the pages.
 
 ## Requirements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 dependencies = [
     "Markdown>=3.3",
     "mkdocs>=1.1",
+    "pathspec>=0.11.1"
 ]
 
 [project.urls]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,6 +1,5 @@
 """Tests for the plugin module."""
 import pytest
-
 from mkdocs_autorefs.plugin import AutorefsPlugin
 
 
@@ -57,3 +56,14 @@ def test_dont_make_relative_urls_relative_again():
             plugin.get_item_url("hello", from_url="baz/bar/foo.html", fallback=lambda _: ("foo.bar.baz",))
             == "../../foo/bar/baz.html#foo.bar.baz"
         )
+
+
+def test_priority_config():
+    """Check that URLs are not made relative more than once."""
+    plugin = AutorefsPlugin()
+    plugin.config = {"priority": ["*", "reference", "foo"]}
+    plugin.register_anchor(identifier="bar.baz", page="reference/baz.html")
+    plugin.register_anchor(identifier="bar.baz", page="baz.html")
+    plugin.register_anchor(identifier="bar.baz", page="foo/bar/baz.html")
+
+    assert plugin.get_item_url("bar.baz") == "baz.html#bar.baz"


### PR DESCRIPTION
Hi,

This PR addresses the need for priority handling when a heading title appears several times throughout the site. The new priority parameter can be set to decide which page will be linked in such cases.

From the updated README:
> If a heading title that appears several times throughout the site, set the priority parameter to decide which page will be linked. The priority list follows the gitignore syntax and is tested in reverse: each anchor will be assigned the lowest priority amongst all of its matches.
```yaml
plugins:
  - search
  - autorefs:
    priority:
      - '*' # priority to all files
      - reference # except reference/... files 
```

Let me know if these changes work for you.