### PR TITLE
build: Migrate to pdm-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["pdm-pep517"]
-build-backend = "pdm.pep517.api"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
 
 [project]
 name = "mkdocs-autorefs"
@@ -49,10 +49,12 @@ Gitter = "https://gitter.im/mkdocstrings/community"
 [project.entry-points."mkdocs.plugins"]
 autorefs = "mkdocs_autorefs.plugin:AutorefsPlugin"
 
-[tool.pdm]
-version = {use_scm = true}
+[tool.pdm.build]
 package-dir = "src"
 editable-backend = "editables"
+
+[tool.pdm.version]
+source = "scm"
 
 [tool.pdm.dev-dependencies]
 duty = ["duty>=0.7"]


### PR DESCRIPTION
Migrate from the deprecated pdm-pep517 backend to pdm-backend that superseded it.  This required moving the build-specific keys from tool.pdm table to tool.pdm.backend, as well as modernizing the SCM version usage.  The artifacts produced after this change are equivalent, except that their names are normalized to "mkdocs_autorefs" as required by modern PyPA standards.

The migration guide is at:
https://pdm-backend.fming.dev/migration/

It does not mention SCM support, probably because the "new" metadata is already supported by newer pdm-pep517 versions.  The docs are at: https://pdm-backend.fming.dev/metadata/#read-from-scm-tag-supporting-git-and-hg