### PR TITLE
Parse `.`-prefixed reference identifiers (relative identifiers)

### DIFF
--- a/duties.py
+++ b/duties.py
@@ -4,17 +4,12 @@ from __future__ import annotations
 
 import os
 import sys
+from importlib.metadata import version as pkgversion
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from duty import duty
 from duty.callables import black, blacken_docs, coverage, lazy, mkdocs, mypy, pytest, ruff, safety
-
-if sys.version_info < (3, 8):
-    from importlib_metadata import version as pkgversion
-else:
-    from importlib.metadata import version as pkgversion
-
 
 if TYPE_CHECKING:
     from duty.context import Context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,3 +100,7 @@ typing = [
 security = [
     "safety>=2",
 ]
+
+[tool.ruff]
+# Full config is in config/ruff.toml
+line-length = 132

--- a/scripts/gen_credits.py
+++ b/scripts/gen_credits.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-import sys
+from importlib.metadata import PackageNotFoundError, metadata
 from itertools import chain
 from pathlib import Path
 from textwrap import dedent
@@ -12,11 +12,6 @@ from typing import Mapping, cast
 import toml
 from jinja2 import StrictUndefined
 from jinja2.sandbox import SandboxedEnvironment
-
-if sys.version_info < (3, 8):
-    from importlib_metadata import PackageNotFoundError, metadata
-else:
-    from importlib.metadata import PackageNotFoundError, metadata
 
 project_dir = Path(".")
 pyproject = toml.load(project_dir / "pyproject.toml")

--- a/src/mkdocs_autorefs/references.py
+++ b/src/mkdocs_autorefs/references.py
@@ -65,7 +65,8 @@ class AutoRefInlineProcessor(ReferenceInlineProcessor):
     def evalId(self, data: str, index: int, text: str) -> EvalIDType:  # noqa: N802 (parent's casing)
         """Evaluate the id portion of `[ref][id]`.
 
-        If `[ref][]` use `[ref]`.
+        If `[ref][]` use "ref".
+        If `[ref][id]` use "id".
 
         Arguments:
             data: The data to evaluate.


### PR DESCRIPTION
This PR intends to add support for relative references

```py
class A:
    """This is a class [A][.] which has a method [m][.m]."""
    def m(self) -> None:
        """This is the method [m][.] on the class [A][..]."""
        return
```

- docs: Document precisely what `evalId` produces in both cases, stripping off the square brackets
- style: Added a `line-length` config in a `tool.ruff` block in `pyproject.toml` so ruff-lsp will not auto-lint the lines incorrectly while editing [clash with pre-commit duty rule]

## Testing

I have set up a Vercel deployment to test the effect of the proposal as I work on it, using a branch on a Vercel/mkdocs "hello world" type demo repo:

- https://github.com/lmmx/docs-pkg/pull/2
- Deployment of the `docs-pkg` repo's `autoref-test` branch: https://docs-pkg-git-autoref-test-lmmx.vercel.app/
  - Specifically using the docstring on the class (thus the API reference entry) [`foo.main.A`](https://docs-pkg-git-autoref-test-lmmx.vercel.app/api/foo/)