### PR TITLE
ci: Fix type of the fallback callable

### DIFF
--- a/src/mkdocs_autorefs/plugin.py
+++ b/src/mkdocs_autorefs/plugin.py
@@ -57,7 +57,7 @@ class AutorefsPlugin(BasePlugin):
         super().__init__()
         self._url_map: dict[str, str] = {}
         self._abs_url_map: dict[str, str] = {}
-        self.get_fallback_anchor: Callable[[str], str | None] | None = None
+        self.get_fallback_anchor: Callable[[str], tuple[str, ...]] | None = None
 
     def register_anchor(self, page: str, identifier: str) -> None:
         """Register that an anchor corresponding to an identifier was encountered when rendering the page.


### PR DESCRIPTION
Following the change in mkdocstrings that replaced `get_anchor` with `get_anchors`, returning a tuple of strings.