### PR TITLE
Added warning for multiple same anchors

### DIFF
--- a/src/mkdocs_autorefs/plugin.py
+++ b/src/mkdocs_autorefs/plugin.py
@@ -90,11 +90,7 @@ class AutorefsPlugin(BasePlugin):
         fallback: Callable[[str], Sequence[str]] | None = None,
     ) -> str:
         try:
-            if len(self._url_map[identifier]) > 1:
-                log.warning(
-                    f"Multiple urls found for '{identifier}': {self._url_map[identifier]}. Please specify a custom unique identifier.",
-                )
-            return self._url_map[identifier][0]
+            urls = self._url_map[identifier]
         except KeyError:
             if identifier in self._abs_url_map:
                 return self._abs_url_map[identifier]
@@ -106,6 +102,13 @@ class AutorefsPlugin(BasePlugin):
                         self._url_map[identifier] = [url]
                         return url
             raise
+        else:
+            if len(urls) > 1:
+                log.warning(
+                    f"Multiple URLs found for '{identifier}': {urls}. "
+                    "Please use unique identifiers, or unique Markdown anchors (see our docs).",
+                )
+            return urls[0]
 
     def get_item_url(
         self,

--- a/src/mkdocs_autorefs/plugin.py
+++ b/src/mkdocs_autorefs/plugin.py
@@ -106,7 +106,7 @@ class AutorefsPlugin(BasePlugin):
             if len(urls) > 1:
                 log.warning(
                     f"Multiple URLs found for '{identifier}': {urls}. "
-                    "Please use unique identifiers, or unique Markdown anchors (see our docs).",
+                    "Make sure to use unique headings, identifiers, or Markdown anchors (see our docs).",
                 )
             return urls[0]
 

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -113,7 +113,7 @@ def test_reference_implicit_with_code_inlinehilite_python() -> None:
         extensions={"pymdownx.inlinehilite": {"style_plain_text": "python"}, "pymdownx.highlight": {}},
         url_map={"pathlib.Path": "pathlib.html#Path"},
         source="This [`pathlib.Path`][].",
-        output='<p>This <a class="autorefs autorefs-internal" href="pathlib.html#Path"><code class="language-python highlight">pathlib.Path</code></a>.</p>',
+        output='<p>This <a class="autorefs autorefs-internal" href="pathlib.html#Path"><code class="highlight">pathlib.Path</code></a>.</p>',
     )
 
 
@@ -325,12 +325,12 @@ def test_register_markdown_anchors() -> None:
             [](){#alias9}
             ## Heading more2 {#heading-custom2}
 
-            [](){#alias10}
-
             [](){#aliasSame}
             ## Same heading 1
             [](){#aliasSame}
             ## Same heading 2
+
+            [](){#alias10}
             """,
         ),
     )

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -113,7 +113,7 @@ def test_reference_implicit_with_code_inlinehilite_python() -> None:
         extensions={"pymdownx.inlinehilite": {"style_plain_text": "python"}, "pymdownx.highlight": {}},
         url_map={"pathlib.Path": "pathlib.html#Path"},
         source="This [`pathlib.Path`][].",
-        output='<p>This <a class="autorefs autorefs-internal" href="pathlib.html#Path"><code class="highlight">pathlib.Path</code></a>.</p>',
+        output='<p>This <a class="autorefs autorefs-internal" href="pathlib.html#Path"><code class="language-python highlight">pathlib.Path</code></a>.</p>',
     )
 
 
@@ -326,22 +326,28 @@ def test_register_markdown_anchors() -> None:
             ## Heading more2 {#heading-custom2}
 
             [](){#alias10}
+
+            [](){#aliasSame}
+            ## Same heading 1
+            [](){#aliasSame}
+            ## Same heading 2
             """,
         ),
     )
     assert plugin._url_map == {
-        "foo": "page#heading-foo",
-        "bar": "page#bar",
-        "alias1": "page#heading-bar",
-        "alias2": "page#heading-bar",
-        "alias3": "page#alias3",
-        "alias4": "page#heading-baz",
-        "alias5": "page#alias5",
-        "alias6": "page#alias6",
-        "alias7": "page#alias7",
-        "alias8": "page#alias8",
-        "alias9": "page#heading-custom2",
-        "alias10": "page#alias10",
+        "foo": ["page#heading-foo"],
+        "bar": ["page#bar"],
+        "alias1": ["page#heading-bar"],
+        "alias2": ["page#heading-bar"],
+        "alias3": ["page#alias3"],
+        "alias4": ["page#heading-baz"],
+        "alias5": ["page#alias5"],
+        "alias6": ["page#alias6"],
+        "alias7": ["page#alias7"],
+        "alias8": ["page#alias8"],
+        "alias9": ["page#heading-custom2"],
+        "alias10": ["page#alias10"],
+        "aliasSame": ["page#same-heading-1", "page#same-heading-2"]
     }
 
 
@@ -366,9 +372,9 @@ def test_register_markdown_anchors_with_admonition() -> None:
         ),
     )
     assert plugin._url_map == {
-        "alias1": "page#alias1",
-        "alias2": "page#heading-bar",
-        "alias3": "page#alias3",
+        "alias1": ["page#alias1"],
+        "alias2": ["page#heading-bar"],
+        "alias3": ["page#alias3"],
     }
 
 

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -347,7 +347,7 @@ def test_register_markdown_anchors() -> None:
         "alias8": ["page#alias8"],
         "alias9": ["page#heading-custom2"],
         "alias10": ["page#alias10"],
-        "aliasSame": ["page#same-heading-1", "page#same-heading-2"]
+        "aliasSame": ["page#same-heading-1", "page#same-heading-2"],
     }
 
 


### PR DESCRIPTION
- Changed url_map to dict[str, list[str]] to allow multiple entries per identifier
- Changed get_item_url to return always the first url found and add a warning because of multiple entries